### PR TITLE
Added 'base' paramaeter to showSwf -> new Swiff.

### DIFF
--- a/cerabox.js
+++ b/cerabox.js
@@ -398,11 +398,13 @@ var CeraBox = CeraBox || new Class({
 					width:ceraBox.options.width?ceraBox.options.width:500,
 					height:ceraBox.options.height?ceraBox.options.height:400
 				},
+				swfBase = /(.*)\/.+(\.swf).*/.exec(currentItem.get('href'))[1],
 				swfEr = new Swiff(currentItem.get('href'), {
 					width: dimension.width,
 					height: dimension.height,
 					params: {
-						wMode: 'opaque'
+						wMode: 'opaque',
+						base : swfBase
 					}
 				});
 


### PR DESCRIPTION
Added Base parameter to Swiff code so any relative URL used in a flash file does not use the page's url but the swf's. 

Handy if you load in an external swf that never expects to get executed in another website and so only has relative urls.
