### PR TITLE
Bugfix: IE throws an error if anchor is not in DOM

### DIFF
--- a/cerabox.js
+++ b/cerabox.js
@@ -920,7 +920,8 @@ window.CeraBoxWindow = (function(window) {
 				currentInstance.options.events.onAnimationEnd.call(currentInstance, currentItem, currentInstance.collection);
 			});
 
-			currentItem.blur();
+			if (document.body.getElement(currentItem))
+				currentItem.blur();
 			windowOpen = true;
 		},
 


### PR DESCRIPTION
If anchor tag that triggers CeraBox was created with JavaScript and is not in the DOM IE throws an error about blurring an element that is not blur-able.
